### PR TITLE
proguard.flags: Don't optimize fragment constructors

### DIFF
--- a/proguard.flags
+++ b/proguard.flags
@@ -2,3 +2,7 @@
 # com.google.errorprone.annotations but don't exist on Android.
 -dontwarn java.lang.ClassValue
 -dontwarn javax.lang.model.element.Modifier
+
+-keep public class * extends android.app.Fragment {
+  public <init>();
+}


### PR DESCRIPTION
09-03 13:08:51.712  4496  4496 E MessageQueue-JNI: Exception in MessageQueue callback: handleReceiveCallback 09-03 13:08:51.713  4496  4496 E MessageQueue-JNI: android.app.Fragment$InstantiationException: Unable to instantiate fragment com.android.dialer.app.settings.DisplayOptionsSettingsFragment: calling Fragment constructor caused an exception
09-03 13:08:51.713  4496  4496 E MessageQueue-JNI:      at android.app.Fragment.instantiate(Fragment.java:565)
09-03 13:08:51.713  4496  4496 E MessageQueue-JNI:      at android.preference.PreferenceActivity.switchToHeaderInner(PreferenceActivity.java:1245)
09-03 13:08:51.713  4496  4496 E MessageQueue-JNI:      at android.preference.PreferenceActivity.switchToHeader(PreferenceActivity.java:1296)
09-03 13:08:51.713  4496  4496 E MessageQueue-JNI:      at android.preference.PreferenceActivity.onHeaderClick(PreferenceActivity.java:1093)
09-03 13:08:51.713  4496  4496 E MessageQueue-JNI:      at com.android.dialer.app.settings.DialerSettingsActivity.onHeaderClick(DialerSettingsActivity.java:45)

Signed-off-by: Aayush Gupta <aayushgupta219@gmail.com>
Signed-off-by: Dmitrii <bankersenator@gmail.com>
Signed-off-by: Pranav Temkar <pranavtemkar@gmail.com>
Change-Id: Idef793065ea422e7506f943bc76cd20e60e0a271